### PR TITLE
Add dockerised development environment helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ fw/BUILD/
 fw/.mbedignore
 
 /bazel-*
+
+.DS_Store
+.cache/

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu
+
+ARG USER_ID
+ARG GROUP_ID
+
+RUN apt-get update
+RUN apt-get install -y python3-pep517 python3-can python3-serial python3-setuptools python3-pyelftools python3-qtpy python3-wheel libtinfo5
+RUN apt-get install -y curl patch git
+
+# RUN addgroup --gid $GROUP_ID user
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
+
+USER user
+
+# ignore git error "detected dubious ownership in repository at '/src'""
+RUN git config --global --add safe.directory /src

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,23 @@
+# docker tools
+
+This directory provides tools to build moteus using docker for environment and virtualisation management.
+
+Moteus manages its own dependencies well via Bazel, but it can still only be run on x86_64 Ubuntu.
+
+This container + script (./env) provides a way to run the build and test tools on other platforms (eg. my M1 Macbook).
+
+| OS | State |
+| --- | ----------- |
+| Linux | Untested - expected to work |
+| OSx | Working 👌 |
+| Windows | Untested - expected to work |
+
+## Setup Notes
+
+This approach has been developed using [docker desktop](https://www.docker.com/products/docker-desktop/)
+
+For OSx specifically, enabling the option "Use Rosetta for x86/amd64 emulation on Apple Silicon" should vastly improve performance.
+
+
+## Usage
+

--- a/tools/docker/env
+++ b/tools/docker/env
@@ -1,0 +1,21 @@
+#!bash
+# fail fast when something goes wrong
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_DIR="$SCRIPT_DIR/../.."
+CACHE_DIR="$REPO_DIR/.cache"
+
+mkdir -p "$CACHE_DIR"
+
+docker build -t myimage \
+  --build-arg USER_ID=$(id -u) \
+  --build-arg GROUP_ID=$(id -g) "$SCRIPT_DIR" \
+  --platform linux/amd64
+
+docker run -it --rm \
+  --mount "type=bind,src=$CACHE_DIR,dst=/home/user/.cache" \
+  --mount "type=bind,src=$REPO_DIR,dst=/src" \
+  --workdir /src \
+  --platform linux/amd64 \
+  myimage bash


### PR DESCRIPTION
## Why?

I found it difficult to get started developing moteus firmware.

I want to make it easier on not just myself, but those who come after me to make improvements to this awesome project :)

## How?

This adds a simple docker container + script to trivially spin up an assured (native if available, else emulated) x86_64 Ubuntu environment
