### PR TITLE
lib: python: remove self-import from setup.py

### DIFF
--- a/lib/python/setup.py.TPL
+++ b/lib/python/setup.py.TPL
@@ -17,8 +17,6 @@
 import setuptools
 import pathlib
 
-import moteus
-
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file


### PR DESCRIPTION
Hi,
I'm currently working on adding support for the python moteus library to OpenEmbedded/YoctoProjects meta-python layer (https://layers.openembedded.org/layerindex/branch/master/layer/meta-python/).

While doing so I've stumbled across a build problem which originates in setup.py importing moteus (which isn't available during its own build step). Therefore this is some kind of a chicken-and-egg problem to me. Furthermore as far as I can tell the moteus import isn't used anywhere within setup.py.

Therefore I suggest to remove the import from setup.py completely.