### PR TITLE
index state is dependent on pin pullmode

### DIFF
--- a/fw/moteus_controller.cc
+++ b/fw/moteus_controller.cc
@@ -283,6 +283,10 @@ enum class Register {
   kEncoder2Position = 0x054,
   kEncoder2Velocity = 0x055,
   kEncoderValidity = 0x058,
+
+  kAux1IndexRaw = 0x059,
+  kAux2IndexRaw = 0x05a,
+
   kAux1GpioCommand = 0x05c,
   kAux2GpioCommand = 0x05d,
   kAux1GpioStatus = 0x05e,
@@ -680,6 +684,8 @@ class MoteusController::Impl : public multiplex::MicroServer::Server {
       case Register::kEncoder2Position:
       case Register::kEncoder2Velocity:
       case Register::kEncoderValidity:
+      case Register::kAux1IndexRaw:
+      case Register::kAux2IndexRaw:
       case Register::kAux1GpioStatus:
       case Register::kAux2GpioStatus:
       case Register::kAux1AnalogIn1:
@@ -919,6 +925,12 @@ class MoteusController::Impl : public multiplex::MicroServer::Server {
             ((status.sources[2].active_theta ? 1 : 0) << 4);
             ((status.sources[2].active_velocity ? 1 : 0) << 5);
         return IntMapping(validity, type);
+      }
+      case Register::kAux1IndexRaw: {
+        return IntMapping(bldc_.aux1().index.raw, type);
+      }
+      case Register::kAux2IndexRaw: {
+        return IntMapping(bldc_.aux2().index.raw, type);
       }
       case Register::kAux1GpioCommand: {
         return IntMapping(PinsToBits(bldc_.aux1().pins), type);


### PR DESCRIPTION
When using Index triggers to disambiguate the motor output, the current code only allows for indexes that pull the gpio HIGH. This works for some sensors, limit switches, etc but others that pull the gpio LOW don't correctly trigger the index.

I have added code to check what the pinmode is set to. If it is ```Pin::Pull::kPullUp``` the logic is flipped so the index can act as expected. 

I wrote this some time ago and have recently updated it to be in the sync with main. I thought I'd make a pull request as it could be useful to others. 

Happy to receive feedback if there is a better way of doing this. Perhaps tying the logic to the pullmode is not obvious and it should be implemented as an addition config value.