### PR TITLE
Fix/initial type issue of moteus result

### DIFF
--- a/lib/python/moteus/moteus.py
+++ b/lib/python/moteus/moteus.py
@@ -530,7 +530,7 @@ class Result:
     id = None
     arbitration_id = None
     bus = None
-    values = []
+    values = {}
 
     def __repr__(self):
         value_str = ', '.join(['{}(0x{:03x}): {}'.format(Register(key).name, key, value)


### PR DESCRIPTION
result.values is actually treated as dict, not as list. Therefore this MR changes the initialization of the member variable to a dict object.