### PR TITLE
fix tview Ctrl-C behavior

### DIFF
--- a/utils/gui/moteus_gui/tview.py
+++ b/utils/gui/moteus_gui/tview.py
@@ -31,6 +31,7 @@ import time
 import traceback
 import matplotlib
 import matplotlib.figure
+import signal
 
 try:
     import PySide6
@@ -1296,4 +1297,5 @@ def main():
 
 
 if __name__ == '__main__':
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
     main()


### PR DESCRIPTION
Previously, while running tview from the command line, pressing Ctrl-C in the terminal would freeze the tview GUI and enter an infinite loop of errors:

https://github.com/user-attachments/assets/05ac12c1-7bc1-4948-917c-39e92a5e5052

I observed this behavior both on Linux running on hardware, and WSL.
It can of course be remedied by simply clicking the X on the tview GUI window, but it bugged me so I took a shot at fixing it by adding a signal catch before calling `main()`. I'm not sure if this is the best way to fix it but it looks like it works! Let me know what you think.

https://github.com/user-attachments/assets/29b98bf7-8ecc-4470-989b-8b457d4a49ab

