### PR TITLE
Add support for CUI AMT22 absolute encoder

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -150,6 +150,7 @@ functions.  Currently supported options include:
 | AS5600          | I2C              | 12 bits        | on-axis     | $         |
 | AksIM-2         | RS422 w/ 5V      | 20 bits        | off-axis    | $$$       |
 | CUI AMT21x      | RS422 w/ 5V      | 14 bits        | shaft       | $$        |
+| CUI AMT22x      | SPI w/ 5V        | 14 bits        | shaft       | $$        |
 | MA600           | SPI              | 16 bits        | on/off-axis | $         |
 | MA732           | SPI              | 14 bits        | on/off-axis | $         |
 | iC-PZ           | SPI w/ 5V        | 22 bits        | off-axis    | $$$       |
@@ -2131,6 +2132,7 @@ The type of SPI device.
 * 3 - iC-PZ
 * 4 - MA732 (CPR == 65536)
 * 5 - MA600 (CPR == 65536)
+* 8 - AMT22 (CPR == 16384)
 
 NOTE: iC-PZ devices require significant configuration and calibration
 before use.  Diagnostic mode commands are provided for low level

--- a/fw/BUILD
+++ b/fw/BUILD
@@ -102,6 +102,7 @@ MOTEUS_SOURCES = [
     "bootloader.h",
     "clock_manager.h",
     "cui_amt21.h",
+    "cui_amt22.h",
     "drv8323.h",
     "drv8323.cc",
     "error.cc",

--- a/fw/aux_common.h
+++ b/fw/aux_common.h
@@ -33,6 +33,7 @@ struct Spi {
       kMa600,
       kOnboardMa600,
       kBoardDefault,
+      kCuiAmt22,
 
       kNumModes,
     };
@@ -69,12 +70,15 @@ struct Spi {
 
     uint8_t ic_pz_bits = 0;
 
+    uint16_t checksum_errors = 0;
+
     template <typename Archive>
     void Serialize(Archive* a) {
       a->Visit(MJ_NVP(active));
       a->Visit(MJ_NVP(value));
       a->Visit(MJ_NVP(nonce));
       a->Visit(MJ_NVP(ic_pz_bits));
+      a->Visit(MJ_NVP(checksum_errors));
     }
   };
 };
@@ -461,6 +465,7 @@ struct IsEnum<moteus::aux::Spi::Config::Mode> {
         { M::kMa600, "ma600" },
         { M::kOnboardMa600, "onboard_ma600" },
         { M::kBoardDefault, "board_default" },
+        { M::kCuiAmt22, "cui_amt22" },
       }};
   }
 };

--- a/fw/cui_amt22.h
+++ b/fw/cui_amt22.h
@@ -1,0 +1,138 @@
+// Copyright 2025 Eli Rutan.  polymetricofficial@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mbed.h"
+
+#include "hal/spi_api.h"
+
+#include "fw/ccm.h"
+#include "fw/moteus_hw.h"
+#include "fw/stm32_spi.h"
+#include "fw/aux_common.h"
+
+
+namespace moteus {
+
+class CuiAmt22 {
+ public:
+  using Options = Stm32Spi::Options;
+
+  CuiAmt22(const Options& options)
+      : spi_([&]() {
+               auto options_copy = options;
+               options_copy.width = 8;
+               options_copy.mode = 0;
+               return options_copy;
+             }()),
+        cs_(std::in_place_t(), options.cs, 1) {
+  }
+
+  /// @return true if we finished reading the sensor and updated the value
+  bool ISR_Update(aux::Spi::Status *status) MOTEUS_CCM_ATTRIBUTE {
+    uint16_t value = 0;
+    switch (state_) {
+      case State::kClearCs: {
+        cs_->clear();
+        state_ = State::kStartFirstByte;
+        return false;
+      }
+      case State::kStartFirstByte: {
+        spi_.start_byte(0x00);
+        state_ = State::kStartSecondByte;
+        return false;
+      }
+      case State::kStartSecondByte: {
+        buffer_[0] = spi_.finish_byte();
+        spi_.start_byte(0x00);
+        state_ = State::kFinishSecondByte;
+        return false;
+      }
+      case State::kFinishSecondByte: {
+        buffer_[1] = spi_.finish_byte();
+        cs_->set();
+
+        if (n_ignored_samples_ < 1) {
+          n_ignored_samples_++;
+          state_ = State::kClearCs;
+          return false;
+        }
+
+        value =
+          ((static_cast<uint16_t>(buffer_[0]) << 8)
+          | static_cast<uint16_t>(buffer_[1]));
+
+        // Check parity - from page 2 of the datasheet:
+        // https://www.sameskydevices.com/product/resource/amt22.pdf
+        const bool received_even_parity = value >> 14 & 1;
+        const bool received_odd_parity = value >> 15 & 1;
+
+        const bool calculated_odd_parity = !(
+            (value >> 13 & 1) ^
+            (value >> 11 & 1) ^
+            (value >> 9  & 1) ^
+            (value >> 7  & 1) ^
+            (value >> 5  & 1) ^
+            (value >> 3  & 1) ^
+            (value >> 1  & 1)
+        );
+        const bool calculated_even_parity = !(
+            (value >> 12 & 1) ^
+            (value >> 10 & 1) ^
+            (value >>  8 & 1) ^
+            (value >>  6 & 1) ^
+            (value >>  4 & 1) ^
+            (value >>  2 & 1) ^
+            (value >>  0 & 1)
+        );
+
+        if (received_odd_parity != calculated_odd_parity ||
+            received_even_parity != calculated_even_parity) {
+          // Parity failed, just wait for the next sample
+          status->checksum_errors++;
+          state_ = State::kClearCs;
+          return false;
+        }
+
+        status->value = value & 0x3fff;
+        status->active = true;
+        status->nonce++;
+        state_ = State::kClearCs;
+        return true;
+      }
+      default: {
+        MJ_ASSERT(false);
+        return false;
+      }
+    }
+  }
+
+ private:
+  Stm32Spi spi_;
+  std::optional<Stm32DigitalOutput> cs_;
+
+  enum class State {
+    kClearCs,
+    kStartFirstByte,
+    kStartSecondByte,
+    kFinishSecondByte,
+  };
+
+  State state_ = State::kClearCs;
+  uint8_t buffer_[2] = {};
+  uint16_t n_ignored_samples_ = 0;
+};
+
+}

--- a/fw/millisecond_timer.h
+++ b/fw/millisecond_timer.h
@@ -96,8 +96,18 @@ class MillisecondTimer {
     }
   }
 
+  void AdvanceMsSinceBoot() {
+    ms_count_++;
+  }
+
+  // This will wrap at around 50 days of uptime.  It should be used
+  // only for operations where is acceptable to have false readings at
+  // that frequency.
+  uint32_t ms_since_boot() const { return ms_count_; }
+
  private:
   TIM_HandleTypeDef handle_ = {};
+  uint32_t ms_count_ = 0;
 };
 
 }

--- a/fw/moteus.cc
+++ b/fw/moteus.cc
@@ -334,6 +334,7 @@ int main(void) {
       moteus_controller.PollMillisecond();
       board_debug.PollMillisecond();
       system_info.SetCanResetCount(fdcan_micro_server.can_reset_count());
+      timer.AdvanceMsSinceBoot();
 
       old_time += 1000;
     }


### PR DESCRIPTION
The CUI AMT22 is a 12- or 14-bit absolute encoder that communicates with SPI. I have the 14 bit version, so this PR so far only supports that. Adding 12-bit support would be trivial.

[Here's the datasheet for the sensor I referenced.](https://www.mouser.com/datasheet/2/1628/amt22_v-3508734.pdf)
The exact part number that I tested with (Mouser) is `490-AMT222B-V`

The AMT22 doesn't like us reading its full 16-bit buffer too fast. So I had to add extra SPI functions to split it up into two separate reads, while holding chip select low, and reading from the SPI data register with only an 8-bit read in order to bypass the data packing feature of the STM32 SPI peripheral.

The AMT22 signal includes two parity bits at the beginning which can be used to verify the received value. I haven't implemented the verification of those yet.

The additional "`no_cs`" SPI functions are different from the original ones in two ways;
1. They don't control the chip select line
2. They use 8-bit values instead of 16-bit
A better way to do this in the future might be to add a chip select boolean parameter to the functions, and separate them into 16-bit and 8-bit variations. This was just the quickest way to get it working that I could think of.

Let me know what you think! Questions, suggestions and criticism are welcome.

https://github.com/user-attachments/assets/88e273ce-9162-433e-9a91-633b4c8d5dbd

