### PR TITLE
fw: move to LPTIM trigger for ADCs

### DIFF
--- a/fw/aux_adc.h
+++ b/fw/aux_adc.h
@@ -53,6 +53,8 @@ class AuxADC {
   void ISR_StartSample() MOTEUS_CCM_ATTRIBUTE {
     if (!any_adc_.load()) { return; }
 
+    // Trigger injected channels using software mode
+    // These are auxiliary measurements that don't require synchronized timing
     if (adc_configs_[0].num_channels) { ADC1->CR |= ADC_CR_JADSTART; }
     if (adc_configs_[1].num_channels) { ADC2->CR |= ADC_CR_JADSTART; }
     if (adc_configs_[2].num_channels) { ADC3->CR |= ADC_CR_JADSTART; }

--- a/fw/moteus_hw.cc
+++ b/fw/moteus_hw.cc
@@ -221,8 +221,10 @@ FamilyAndVersion DetectMoteusFamily(MillisecondTimer* timer) {
         (17 << ADC_SQR1_SQ1_Pos) |  // IN17
         (0 << ADC_SQR1_L_Pos);  // length 1
 
-    EnableAdc(timer, ADC2, 16, 0);
+    // Use software trigger for one-time measurement during detection
+    EnableAdc(timer, ADC2, 16, 0, AdcTriggerMode::kSoftware);
 
+    // Trigger ADC2 using software mode
     ADC2->CR |= ADC_CR_ADSTART;
     while ((ADC2->ISR & ADC_ISR_EOC) == 0);
 

--- a/fw/stm32g4_adc.h
+++ b/fw/stm32g4_adc.h
@@ -21,6 +21,11 @@
 
 namespace moteus {
 
+enum class AdcTriggerMode {
+  kSoftware,      // Software trigger (manual ADSTART)
+  kLptim1,        // Hardware trigger from LPTIM1_OUT
+};
+
 inline void DisableAdc(ADC_TypeDef* adc) {
   if (adc->CR & ADC_CR_ADEN) {
     adc->CR |= ADC_CR_ADDIS;
@@ -29,5 +34,17 @@ inline void DisableAdc(ADC_TypeDef* adc) {
 }
 
 // This function needs to be in CCM memory to achieve deterministic timings.
-void EnableAdc(MillisecondTimer* timer, ADC_TypeDef* adc, int prescaler, int offset) MOTEUS_CCM_ATTRIBUTE;
+void EnableAdc(MillisecondTimer* timer, ADC_TypeDef* adc, int prescaler, int offset,
+               AdcTriggerMode trigger_mode = AdcTriggerMode::kSoftware) MOTEUS_CCM_ATTRIBUTE;
+
+// Helper to trigger all ADCs simultaneously using LPTIM1
+inline void TriggerAllAdcs() {
+  // Generate LPTIM_OUT pulse to trigger ADC1-ADC4 simultaneously
+  // LPTIM1 is already enabled and configured during initialization
+  // Wait for any previous operation to complete
+  while (LPTIM1->CR & LPTIM_CR_SNGSTRT);
+
+  // Start single pulse generation
+  LPTIM1->CR |= LPTIM_CR_SNGSTRT;
+}
 }


### PR DESCRIPTION
Rather than using inline ASM, use an actual HW trigger with LPTIM out.