### PR TITLE
fw: fix drv8353 low-side IDRIVEN table selection

### DIFF
--- a/fw/drv8323.cc
+++ b/fw/drv8323.cc
@@ -357,7 +357,7 @@ class Drv8323::Impl {
         (map_choice(tdrive_ns_table, config_.tdrive_ns) << 8) |
         (map_choice(drv8323 ? idrivep_table_drv8323 : idrivep_table_drv8353,
                     config_.idrivep_ls_ma) << 4) |
-        (map_choice(drv8323 ? idriven_table_drv8323 : idrivep_table_drv8353,
+        (map_choice(drv8323 ? idriven_table_drv8323 : idriven_table_drv8353,
                     config_.idriven_ls_ma) << 0);
 
     const uint16_t reg5 =


### PR DESCRIPTION
Corrects the DRV8353 low-side sink current table selection in `fw/drv8323.cc:360`.
- The code previously used `idrivep_table_drv8353` for `config_.idriven_ls_ma`.
- It now correctly uses `idriven_table_drv8353`, matching the intended IDRIVEN low-side configuration.